### PR TITLE
Robust error handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,13 +23,14 @@ linters:
     - ireturn
     - lll
     - nlreturn
+    - tagliatelle
     - varnamelen
     - wrapcheck
     - wsl
 
-linters-settings:
-  tagliatelle:
-    case:
-      use-field-name: true
-      rules:
-        json: snake
+# linters-settings:
+#   tagliatelle:
+#     case:
+#       use-field-name: true
+#       rules:
+#         json: snake

--- a/database/user.go
+++ b/database/user.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 
 	"github.com/IV1201-Group-2/login-service/model"
-	// Initializes Postgres driver.
+	// Imports Postgres driver.
 	_ "github.com/lib/pq"
 )
 

--- a/model/api.go
+++ b/model/api.go
@@ -1,39 +1,10 @@
 // The package model contains structures that model API and user data.
 package model
 
-const (
-	// Unknown error.
-	APIErrUnknown = "UNKNOWN"
-
-	// User did not provide identity, password or desired role.
-	APIErrMissingParameters = "MISSING_PARAMETERS"
-	// User does not have a password in the database.
-	APIErrMissingPassword = "MISSING_PASSWORD"
-
-	// No account was found with that specific username or email address.
-	APIErrWrongIdentity = "WRONG_IDENTITY"
-	// Account was found but the wrong password was provided.
-	APIErrWrongPassword = "WRONG_PASSWORD"
-
-	// User is already logged in (JWT token was provided).
-	APIErrAlreadyLoggedIn = "ALREADY_LOGGED_IN"
-	// User did not provide a token for reset API.
-	APIErrTokenNotProvided = "TOKEN_NOT_PROVIDED" // #nosec G101
-)
-
-// Specific success response for this API.
-type SuccessResponse struct {
+type UserTokenResponse struct {
 	Token string `json:"token"`
 }
 
-// Provides additional details about an error.
-type ErrorDetails struct {
-	Message    string `json:"message,omitempty"`
-	ResetToken string `json:"reset_token,omitempty"`
-}
-
-// Shared error response for all APIs.
-type ErrorResponse struct {
-	Error   string        `json:"error"`
-	Details *ErrorDetails `json:"details,omitempty"`
+type ResetTokenResponse struct {
+	ResetToken string `json:"reset_token"`
 }

--- a/model/error.go
+++ b/model/error.go
@@ -1,0 +1,69 @@
+package model
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Represents an error that occurred in the service layer.
+type APIError struct {
+	// HTTP status code.
+	StatusCode int `json:"-"`
+	// Error type.
+	ErrorType string `json:"error"`
+	// Error details.
+	Details any `json:"details,omitempty"`
+	// Internal wrapped error. Not visible to users.
+	Internal error `json:"-"`
+}
+
+// Attaches detailed user-visible information to an API error.
+// This is intended to give the API consumer more information about where and how it occurred.
+func (a *APIError) WithDetails(details any) *APIError {
+	return &APIError{StatusCode: a.StatusCode, ErrorType: a.ErrorType, Details: details, Internal: a.Internal}
+}
+
+// Attaches an internal error to an API error.
+func (a *APIError) WithInternal(err error) *APIError {
+	return &APIError{StatusCode: a.StatusCode, ErrorType: a.ErrorType, Details: a.Details, Internal: err}
+}
+
+// Describes the API error.
+func (a *APIError) Error() string {
+	if a.Internal != nil {
+		return fmt.Sprintf("%s (%v)", a.ErrorType, a.Internal)
+	}
+	return a.ErrorType
+}
+
+// If an error has been wrapped in a.Internal, return the error.
+func (a *APIError) Unwrap() error {
+	return a.Internal
+}
+
+var (
+	// Unknown error.
+	ErrUnknown = &APIError{http.StatusInternalServerError, "UNKNOWN", nil, nil}
+	// An external service such as the database is unavailable.
+	ErrServiceUnavailable = &APIError{http.StatusInternalServerError, "SERVICE_UNAVAILABLE", nil, nil}
+
+	// User did not provide identity, password or desired role.
+	ErrMissingParameters = &APIError{http.StatusBadRequest, "MISSING_PARAMETERS", nil, nil}
+	// User does not have a password in the database.
+	ErrMissingPassword = &APIError{http.StatusNotFound, "MISSING_PASSWORD", nil, nil}
+
+	// No account was found with that specific username or email address.
+	ErrWrongIdentity = &APIError{http.StatusUnauthorized, "WRONG_IDENTITY", nil, nil}
+	// Account was found but the wrong password was provided.
+	ErrWrongPassword = &APIError{http.StatusUnauthorized, "WRONG_PASSWORD", nil, nil}
+
+	// User is already logged in (JWT token was provided).
+	ErrAlreadyLoggedIn = &APIError{http.StatusBadRequest, "ALREADY_LOGGED_IN", nil, nil}
+	// User did not provide a token for reset API.
+	ErrTokenNotProvided = &APIError{http.StatusUnauthorized, "TOKEN_NOT_PROVIDED", nil, nil} // #nosec G101
+	// User provided an invalid or expired token.
+	ErrTokenInvalid = &APIError{http.StatusUnauthorized, "INVALID_TOKEN", nil, nil}
+
+	// User tried to access an invalid route.
+	ErrInvalidRoute = &APIError{http.StatusNotFound, "INVALID_ROUTE", nil, nil}
+)

--- a/service/jwt.go
+++ b/service/jwt.go
@@ -22,6 +22,9 @@ func errorHandlerFunc(_ echo.Context, err error) error {
 	if errors.Is(err, echojwt.ErrJWTMissing) {
 		return nil
 	}
+	if errors.Is(err, echojwt.ErrJWTInvalid) {
+		return model.ErrTokenInvalid.WithInternal(err)
+	}
 
 	return err
 }

--- a/service/login.go
+++ b/service/login.go
@@ -22,28 +22,26 @@ func Login(c echo.Context, db database.Connection, authConfig *echojwt.Config) e
 	// Check if user incorrectly provided a JWT token
 	_, ok := c.Get("user").(*jwt.Token)
 	if ok {
-		return c.JSON(http.StatusBadRequest, model.ErrorResponse{Error: model.APIErrAlreadyLoggedIn})
+		return model.ErrAlreadyLoggedIn
 	}
 
 	var params loginParams
 	// Check that all parameters are present
 	if err := errors.Join(c.Bind(&params), c.Validate(&params)); err != nil {
-		return c.JSON(http.StatusBadRequest, model.ErrorResponse{Error: model.APIErrMissingParameters})
+		return model.ErrMissingParameters
 	}
 
 	user, err := db.QueryUser(params.Identity)
 	if err != nil {
 		if errors.Is(err, database.ErrUserNotFound) {
-			return c.JSON(http.StatusUnauthorized, model.ErrorResponse{Error: model.APIErrWrongIdentity})
+			return model.ErrWrongIdentity
 		}
-		c.Logger().Errorf("QueryUser: %v", err)
-		// TODO: Handle DB connection failure gracefully
-		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{Error: model.APIErrUnknown})
+		return err
 	}
 
 	// If the caller specified a role, we want to check if the user matches expectations
 	if params.Role > 0 && params.Role != user.Role {
-		return c.JSON(http.StatusUnauthorized, model.ErrorResponse{Error: model.APIErrWrongIdentity})
+		return model.ErrWrongIdentity
 	}
 
 	// Check that user has a valid password in the database
@@ -51,28 +49,20 @@ func Login(c echo.Context, db database.Connection, authConfig *echojwt.Config) e
 		// Create a new reset token allowing the user to reset their password
 		token, err := SignResetToken(*user, authConfig.SigningKey)
 		if err != nil {
-			c.Logger().Errorf("SignResetToken: %v", err)
-			return c.JSON(http.StatusInternalServerError, model.ErrorResponse{Error: model.APIErrUnknown})
+			return err
 		}
-		response := model.ErrorResponse{
-			Error: model.APIErrMissingPassword,
-			Details: &model.ErrorDetails{
-				ResetToken: token,
-			},
-		}
-		return c.JSON(http.StatusNotFound, response)
+		return model.ErrMissingPassword.WithDetails(model.ResetTokenResponse{ResetToken: token})
 	}
 
 	// Check that password matches
 	if !model.ComparePassword(params.Password, user.Password) {
-		return c.JSON(http.StatusUnauthorized, model.ErrorResponse{Error: model.APIErrWrongPassword})
+		return model.ErrWrongPassword
 	}
 
 	// Create a new token valid for auth expiry period
 	token, err := SignUserToken(*user, authConfig.SigningKey)
 	if err != nil {
-		c.Logger().Errorf("SignUserToken: %v", err)
-		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{Error: model.APIErrUnknown})
+		return err
 	}
-	return c.JSON(http.StatusOK, model.SuccessResponse{Token: token})
+	return c.JSON(http.StatusOK, model.UserTokenResponse{Token: token})
 }

--- a/service/login_test.go
+++ b/service/login_test.go
@@ -85,7 +85,7 @@ func TestLogin(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, res.StatusCode)
 
-	obj := model.SuccessResponse{}
+	obj := model.UserTokenResponse{}
 	body, _ := io.ReadAll(res.Body)
 
 	// Parse the response
@@ -113,11 +113,11 @@ func TestMissingParameters(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 
-	obj := model.ErrorResponse{}
+	obj := model.APIError{}
 	body, _ := io.ReadAll(res.Body)
 
 	require.NoError(t, json.Unmarshal(body, &obj))
-	require.Equal(t, "MISSING_PARAMETERS", obj.Error)
+	require.Equal(t, "MISSING_PARAMETERS", obj.ErrorType)
 }
 
 // Tests that the server does not return MISSING_PARAMETERS when API caller is missing optional parameters.
@@ -146,11 +146,11 @@ func TestLoginMissingUser(t *testing.T) {
 
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 
-	obj := model.ErrorResponse{}
+	obj := model.APIError{}
 	body, _ := io.ReadAll(res.Body)
 
 	require.NoError(t, json.Unmarshal(body, &obj))
-	require.Equal(t, "WRONG_IDENTITY", obj.Error)
+	require.Equal(t, "WRONG_IDENTITY", obj.ErrorType)
 }
 
 // Tests that the server returns WRONG_IDENTITY when user has a different role.
@@ -166,11 +166,11 @@ func TestLoginWrongRole(t *testing.T) {
 
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 
-	obj := model.ErrorResponse{}
+	obj := model.APIError{}
 	body, _ := io.ReadAll(res.Body)
 
 	require.NoError(t, json.Unmarshal(body, &obj))
-	require.Equal(t, "WRONG_IDENTITY", obj.Error)
+	require.Equal(t, "WRONG_IDENTITY", obj.ErrorType)
 }
 
 // Tests that the server returns WRONG_PASSWORD when user has wrong password.
@@ -186,11 +186,11 @@ func TestLoginWrongPassword(t *testing.T) {
 
 	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
 
-	obj := model.ErrorResponse{}
+	obj := model.APIError{}
 	body, _ := io.ReadAll(res.Body)
 
 	require.NoError(t, json.Unmarshal(body, &obj))
-	require.Equal(t, "WRONG_PASSWORD", obj.Error)
+	require.Equal(t, "WRONG_PASSWORD", obj.ErrorType)
 }
 
 // Tests that the server returns ALREADY_LOGGED_IN when a JWT token is set.
@@ -210,11 +210,11 @@ func TestAlreadyLoggedIn(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, res.StatusCode)
 
-	obj := model.ErrorResponse{}
+	obj := model.APIError{}
 	body, _ := io.ReadAll(res.Body)
 
 	require.NoError(t, json.Unmarshal(body, &obj))
-	require.Equal(t, "ALREADY_LOGGED_IN", obj.Error)
+	require.Equal(t, "ALREADY_LOGGED_IN", obj.ErrorType)
 }
 
 // Tests that the server returns an error conformant with shared API rules on wrong route.
@@ -226,12 +226,11 @@ func TestWrongRoute(t *testing.T) {
 
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 
-	obj := model.ErrorResponse{}
+	obj := model.APIError{}
 	body, _ := io.ReadAll(res.Body)
 
 	require.NoError(t, json.Unmarshal(body, &obj))
-	require.Equal(t, "UNKNOWN", obj.Error)
-	require.NotNil(t, obj.Details)
+	require.Equal(t, "INVALID_ROUTE", obj.ErrorType)
 }
 
 // TODO: Test missing password

--- a/service/reset.go
+++ b/service/reset.go
@@ -21,34 +21,30 @@ func PasswordReset(c echo.Context, db database.Connection, authConfig *echojwt.C
 	// TODO: Verify that Echo checks expiry period
 	token, ok := c.Get("user").(*jwt.Token)
 	if !ok {
-		return c.JSON(http.StatusUnauthorized, model.ErrorResponse{Error: model.APIErrTokenNotProvided})
+		return model.ErrTokenNotProvided
 	}
 
 	// Check if user provided a reset token
 	claims, _ := token.Claims.(*model.CustomUserClaims)
 	if claims.Usage != model.TokenUsageReset {
-		return c.JSON(http.StatusBadRequest, model.ErrorResponse{Error: model.APIErrAlreadyLoggedIn})
+		return model.ErrAlreadyLoggedIn
 	}
 
 	var params resetParams
 	// Check that all parameters are present
 	if err := errors.Join(c.Bind(&params), c.Validate(&params)); err != nil {
-		return c.JSON(http.StatusBadRequest, model.ErrorResponse{Error: model.APIErrMissingParameters})
+		return model.ErrMissingParameters
 	}
 
 	err := db.UpdatePassword(claims.User.ID, params.Password)
 	if err != nil {
-		// TODO: Handle DB connection failure gracefully
-		// This should not occur under any other condition
-		c.Logger().Errorf("UpdatePassword: %v", err)
-		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{Error: model.APIErrUnknown})
+		return err
 	}
 
 	// Create a new token valid for auth expiry period
 	newToken, err := SignUserToken(claims.User, authConfig.SigningKey)
 	if err != nil {
-		c.Logger().Errorf("SignUserToken: %v", err)
-		return c.JSON(http.StatusInternalServerError, model.ErrorResponse{Error: model.APIErrUnknown})
+		return err
 	}
-	return c.JSON(http.StatusOK, model.SuccessResponse{Token: newToken})
+	return c.JSON(http.StatusOK, model.UserTokenResponse{Token: newToken})
 }

--- a/service/util.go
+++ b/service/util.go
@@ -3,34 +3,57 @@
 package service
 
 import (
+	"database/sql"
 	"errors"
-	"fmt"
-	"net/http"
+	"net"
+	"syscall"
 
 	"github.com/IV1201-Group-2/login-service/model"
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
 )
 
+// Rewrites errors returned by Echo to follow shared API rules.
+func rewriteEchoErrors(err *echo.HTTPError, c echo.Context) *model.APIError {
+	result := model.ErrUnknown.WithInternal(err)
+	if errors.Is(echo.ErrNotFound, err) ||
+		errors.Is(echo.ErrForbidden, err) ||
+		errors.Is(echo.ErrMethodNotAllowed, err) {
+		result = model.ErrInvalidRoute.WithInternal(err)
+	}
+	c.Logger().Errorf("[%s] Rewrote framework error %d to %s", c.RealIP(), err.Code, result.ErrorType)
+	return result
+}
+
 // Custom error handler conformant with shared API rules.
-// https://echo.labstack.com/docs/error-handling
 func ErrorHandler(err error, c echo.Context) {
-	c.Logger().Errorf("ErrorHandler: %v", err)
+	userVisibleErr := model.ErrUnknown.WithInternal(err)
 
-	var details *model.ErrorDetails
-	code := http.StatusInternalServerError
-
+	var apiErr *model.APIError
 	var httpErr *echo.HTTPError
-	if errors.As(err, &httpErr) {
-		details = &model.ErrorDetails{Message: fmt.Sprintf("%v", httpErr.Message)}
-		code = httpErr.Code
+
+	switch {
+	case errors.As(err, &apiErr):
+		c.Logger().Errorf("[%s] Error occurred in handler: %v", c.RealIP(), err)
+		userVisibleErr = apiErr
+	case errors.As(err, &httpErr):
+		c.Logger().Errorf("[%s] Error occurred in framework: %v", c.RealIP(), err)
+		// Special case for some framework errors
+		userVisibleErr = rewriteEchoErrors(httpErr, c)
+	case errors.Is(err, sql.ErrConnDone):
+	case errors.Is(err, sql.ErrTxDone):
+	case errors.Is(err, net.ErrClosed):
+	case errors.Is(err, syscall.ECONNREFUSED):
+	case errors.Is(err, syscall.ECONNABORTED):
+	case errors.Is(err, syscall.ECONNRESET):
+		c.Logger().Errorf("[%s] Error occurred in database: %v", c.RealIP(), err)
+		userVisibleErr = model.ErrServiceUnavailable.WithInternal(err)
+	default:
+		c.Logger().Errorf("[%s] Recovered from unexpected error: %v", c.RealIP(), err)
 	}
 
-	if err := c.JSON(code, model.ErrorResponse{
-		Error:   model.APIErrUnknown,
-		Details: details,
-	}); err != nil {
-		c.Logger().Error(err)
+	if err := c.JSON(userVisibleErr.StatusCode, userVisibleErr); err != nil {
+		c.Logger().Errorf("[%s] Error occurred in HTTP error handler: %v", c.RealIP(), err)
 	}
 }
 
@@ -41,13 +64,13 @@ type Validator struct {
 
 // NewValidator creates a new instance of service.Validator.
 func NewValidator() *Validator {
-	return &Validator{validator: validator.New()}
+	return &Validator{validator: validator.New(validator.WithRequiredStructEnabled())}
 }
 
 // Validates user data using go-playground/validator.
 func (cv *Validator) Validate(i interface{}) error {
 	if err := cv.validator.Struct(i); err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("validation failed: %s", err.Error()))
+		return model.ErrMissingParameters
 	}
 
 	return nil


### PR DESCRIPTION
Closes #19

* Status code is now part of error type
* JWT errors are rewritten to INVALID_TOKEN
* Framework errors are rewritten to INVALID_ROUTE/UNKNOWN
* Database errors are rewritten to SERVICE_UNAVAILABLE
* No internal error details are leaked to the user